### PR TITLE
Fixes issue that default values aren't honored

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -96,6 +96,7 @@ pub fn get_matcher<'a>(
             Arg::with_name(option.name)
                 .long(option.name)
                 .value_name(option.name)
+                .default_value(option.default)
                 .help(option.help)
                 .takes_value(option.takes_argument)
                 .overrides_with(option.name)
@@ -213,6 +214,10 @@ mod tests {
             matcher.value_of(TestConfig::TEST_PARAM.name).unwrap(),
             "param1"
         );
+        assert_eq!(
+            matcher.value_of(TestConfig::TEST_PARAM2.name).unwrap(),
+            TestConfig::TEST_PARAM2.default
+        )
     }
 
     #[test]


### PR DESCRIPTION
Default values are currently required in the ConfigOption but they are not honored.
We should probably make "default" values optional but that's for another Pull Request.